### PR TITLE
Small fix of the KTools::inverseOf() return type

### DIFF
--- a/src/common/algebra.hpp
+++ b/src/common/algebra.hpp
@@ -399,7 +399,7 @@ namespace KTools {
 	}
 
 	template<typename T>
-	inline void inverseOf(const ProjectiveMatrix<2, T>& M) {
+	inline ProjectiveMatrix<2, T> inverseOf(const ProjectiveMatrix<2, T>& M) {
 		ProjectiveMatrix<2, T> N(M);
 		invert(N);
 		return N;


### PR DESCRIPTION
Should fix the https://github.com/nsimplex/ktools/issues/12 as I've faced that one as well (Debian 8.3.0-6, gcc 8.3.0):

```txt
Scanning dependencies of target ktool_common
[  3%] Building CXX object CMakeFiles/ktool_common.dir/src/common/ktools_common.cpp.o
[  6%] Building CXX object CMakeFiles/ktool_common.dir/src/common/file_abstraction.cpp.o
[ 10%] Building CXX object CMakeFiles/ktool_common.dir/src/common/ktex/ktex.cpp.o
[ 13%] Building CXX object CMakeFiles/ktool_common.dir/src/common/ktex/specs.cpp.o
[ 16%] Building CXX object CMakeFiles/ktool_common.dir/src/common/atlas.cpp.o
In file included from /tmp/ktools-4.4.0/src/common/atlas.hpp:24,
                 from /tmp/ktools-4.4.0/src/common/atlas.cpp:18:
/tmp/ktools-4.4.0/src/common/algebra.hpp: In function 'void KTools::inverseOf(const KTools::ProjectiveMatrix<2, T>&)':
/tmp/ktools-4.4.0/src/common/algebra.hpp:405:10: error: return-statement with a value, in function returning 'void' [-fpermissive]
   return N;
          ^
make[2]: *** [CMakeFiles/ktool_common.dir/build.make:115: CMakeFiles/ktool_common.dir/src/common/atlas.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:183: CMakeFiles/ktool_common.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```