### PR TITLE
Migrate ImageMagick from 6 to 7

### DIFF
--- a/src/krane/kbuild.cpp
+++ b/src/krane/kbuild.cpp
@@ -44,9 +44,9 @@ namespace Krane {
 		mask.monochrome(true);
 		mask.fillColor(ColorMono(false));
 
-		list<Drawable> drawable_trigs;
+		vector<Drawable> drawable_trigs;
 		size_t ntrigs = uvwtriangles.size();
-		list<Coordinate> coords;
+		vector<Coordinate> coords;
 		for(size_t i = 0; i < ntrigs; i++) {
 			const uvwtriangle_type& trig = uvwtriangles[i];
 
@@ -96,9 +96,9 @@ namespace Krane {
 
 		// Returned image (clipped quad).
 		Image img = Image(geo, "transparent");
-		img.clipMask(mask);
+		img.readMask(mask);
 		MAGICK_WRAP(img.composite( quad, Geometry(0, 0), OverCompositeOp ));
-		img.clipMask(Image());
+		img.readMask(Image());
 
 
 		// This is to reverse the scaling down applied by the mod tools' scml compiler.
@@ -177,13 +177,13 @@ namespace Krane {
 		// Returned image.
 		Magick::Image markedatlas(atlas.size(), "transparent");
 
-		markedatlas.clipMask(inversemask);
+		markedatlas.readMask(inversemask);
 		MAGICK_WRAP(markedatlas.composite( bg, Geometry(0, 0), OverCompositeOp ));
 
-		markedatlas.clipMask(mask);
+		markedatlas.readMask(mask);
 		MAGICK_WRAP(markedatlas.composite( atlas, Geometry(0, 0), OverCompositeOp ));
 
-		markedatlas.clipMask(Image());
+		markedatlas.readMask(Image());
 
 		markedatlas.flip();
 		return markedatlas;

--- a/src/krane/krane.cpp
+++ b/src/krane/krane.cpp
@@ -234,7 +234,7 @@ static void configure_bank_collection(KAnimBankCollection& banks) {
 }
 
 static void sanitize_output_png(Magick::Image& img) {
-	img.type(Magick::TrueColorMatteType);
+	img.type(Magick::TrueColorAlphaType);
 	img.colorSpace(Magick::sRGBColorspace);
 
 	// png color type 6 means RGBA
@@ -359,6 +359,6 @@ int main(int argc, char* argv[]) {
 		cerr << "ERROR" << endl;
 		return -1;
 	}
-	
+
 	return 0;
 }

--- a/src/ktech/ktech_options.cpp
+++ b/src/ktech/ktech_options.cpp
@@ -53,7 +53,7 @@ namespace KTech {
 
 		int image_quality = 100;
 
-		Magick::FilterTypes filter = Magick::LanczosFilter;
+		MagickCore::FilterType filter = MagickCore::LanczosFilter;
 
 		bool no_premultiply = false;
 
@@ -124,10 +124,10 @@ namespace KTech {
 			}
 		};
 
-		class FilterTypeTranslator : public StrOptTranslator<Magick::FilterTypes> {
+		class FilterTypeTranslator : public StrOptTranslator<MagickCore::FilterType> {
 		public:
 			FilterTypeTranslator() {
-				using namespace Magick;
+				using namespace MagickCore;
 
 				push_opt("lanczos", LanczosFilter);
 				push_opt("mitchell", MitchellFilter);

--- a/src/ktech/ktech_options.hpp
+++ b/src/ktech/ktech_options.hpp
@@ -30,7 +30,7 @@ namespace KTech {
 
 		extern int image_quality;
 
-		extern Magick::FilterTypes filter;
+		extern MagickCore::FilterType filter;
 
 		extern bool no_premultiply;
 


### PR DESCRIPTION
Based on the porting guide: https://imagemagick.org/script/porting.php

Seems to work fine. Tested on both:

- Linux ([ImageMagick][] 7.1.0-5 compiled from source)
- macOS ([ImageMagick][] 7.1.0-4 installed using [Homebrew][]).

Should fix at least https://github.com/nsimplex/ktools/issues/7 and https://github.com/nsimplex/ktools/issues/18.

_P.S. As it's very unlikely that this PR will be merged soon, so quick note for "fork investigators": this PR will be a part of my [v4.5.0](https://github.com/victorpopkov/ktools/releases)._

[homebrew]: https://brew.sh/
[imagemagick]: https://imagemagick.org/index.php