### PR TITLE
Enable --no-premultiply option

### DIFF
--- a/src/ktech/image_processing.hpp
+++ b/src/ktech/image_processing.hpp
@@ -164,12 +164,12 @@ namespace ImOp {
 			}
 
 			if(!options::no_premultiply) {
-				if(verbosity >= 1) {
+				if(options::verbosity >= 1) {
 					std::cout << "Premultiplying alpha..." << std::endl;
 				}
 				std::for_each( imgs.begin(), imgs.end(), ImOp::premultiplyAlpha() );
 			}
-			else if(verbosity >= 1) {
+			else if(options::verbosity >= 1) {
 				std::cout << "Skipping alpha premultiplication..." << std::endl;
 			}
 
@@ -210,12 +210,12 @@ namespace ImOp {
 			}
 
 			if(!options::no_premultiply) {
-				if(verbosity >= 1) {
+				if(options::verbosity >= 1) {
 					std::cout << "Demultiplying alpha..." << std::endl;
 				}
 				std::for_each( imgs.begin(), imgs.end(), ImOp::demultiplyAlpha() );
 			}
-			else if(verbosity >= 1) {
+			else if(options::verbosity >= 1) {
 				std::cout << "Skipping alpha demultiplication..." << std::endl;
 			}
 

--- a/src/ktech/ktech_options.cpp
+++ b/src/ktech/ktech_options.cpp
@@ -291,9 +291,7 @@ KTEX::File::Header KTech::parse_commandline_options(int& argc, char**& argv, std
 
 		options::filter = filter_trans.translate(filter_opt.getValue());
 
-		/*
 		options::no_premultiply = no_premultiply_flag.getValue();
-		*/
 
 		options::no_mipmaps = no_mipmaps_flag.getValue();
 


### PR DESCRIPTION
Have decided to investigate the https://github.com/nsimplex/ktools/issues/6 issue, as I've thought that it was something to do with alpha compositing. Since premultiplied alpha is used by default, there was also an option (`--no-premultiply`) that happened to be disabled.

_P.S. Just like https://github.com/nsimplex/ktools/pull/19, I don't think this will be merged in a near future, so, "fork divers", this PR will be a part of my [v4.5.0](https://github.com/victorpopkov/ktools/releases) as well._